### PR TITLE
Clear the flash storage when the cookie has been tampered with.

### DIFF
--- a/src/djangoflash/middleware.py
+++ b/src/djangoflash/middleware.py
@@ -63,7 +63,12 @@ def _get_flash_from_storage(request):
     """Gets the flash from the storage, adds it to the given request and
     returns it. A new :class:`FlashScope` is used if the storage is empty.
     """
-    flash = storage.get(request) or FlashScope()
+    try:
+        flash = storage.get(request) or FlashScope()
+    except SuspiciousOperation:
+        # Clear the storage if the cookie has been tampered with.
+        flash = FlashScope()
+
     setattr(request, CONTEXT_VAR, flash)
     return flash
 


### PR DESCRIPTION
The company I work for keeps hitting 500 errors on pages due to the flash message's cookie being tampered with. I believe when the cookie has been tampered with, then the storage should just be thrown away. That's the only sensible thing you can do at that point.

If this pull request isn't acceptable, could you move this function into a method in the `FlashMiddleware` class instead, so I can override it in my codebase? At the moment, I just copy and pasted your entire middleware class out to replace this function.
